### PR TITLE
Add col-wise

### DIFF
--- a/src/redux/core.cljc
+++ b/src/redux/core.cljc
@@ -55,3 +55,17 @@
                  (into {})))
       (pre-step (project kvs))
       (post-complete complete-triangular-matrix)))
+
+(defn col-wise [& rfs]
+  (fn
+    ([] (mapv (fn [rf] (rf)) rfs))
+    ([accs] (mapv (fn [rf acc] (rf (unreduced acc))) rfs accs))
+    ([accs row]
+     (let [all-reduced? (volatile! true)
+           results (mapv (fn [rf acc x]
+                           (if-not (reduced? acc)
+                             (do (vreset! all-reduced? false)
+                                 (rf acc x))
+                             acc))
+                         rfs accs row)]
+       (if @all-reduced? (reduced results) results)))))

--- a/test/redux/core_test.cljc
+++ b/test/redux/core_test.cljc
@@ -44,3 +44,6 @@
     (is (= (transduce identity (r/fuse-matrix rf {:a inc :b identity :c dec}) (range 10))
            {[:a :b] 100, [:a :c] 90, [:b :c] 80,
             [:b :a] 100, [:c :a] 90, [:c :b] 80}))))
+
+(deftest col-wise-test
+  (is (= [6 [:a :b :c]] (transduce identity (r/col-wise + conj) [[1 :a] [2 :b] [3 :c]]))))


### PR DESCRIPTION
Not sure if this is something that's generally useful, but when working with tabular data you often want to somehow summarize all cols in a single pass. This adds `col-wise` (shitty name) which works similar to `juxt` except each rf is applied to the corresponding col in a row (rather than all to the same datum).